### PR TITLE
use regex to fix censored word

### DIFF
--- a/app/Http/Controllers/RoomMessageController.php
+++ b/app/Http/Controllers/RoomMessageController.php
@@ -23,7 +23,13 @@ class RoomMessageController extends Controller
 
             // Bad Words Filter
             $badwords = trans('bad-words');
-            $body = str_ireplace($badwords, '*****', Request::input('body'));
+            
+            // Use regex to match whole words only
+            $badwordsregex = array_map(function ($word) {
+                return '/\b' . trim($word) . '\b/i';
+            }, $badwords);
+
+            $body = preg_replace($badwordsregex, '*****', Request::input('body'));
 
             $message = $room->messages()->create([
                 'user_id' => Auth::user()->id,


### PR DESCRIPTION
Pour regler le soucis #97 

J'ai modifié la fonction _str_ireplace_ par la fonction _preg_replace_, pour filtrer à l'aide de regex et éviter les faux positifs.
Pour éviter de modifier directement l'array bad-words, je l'ai map dans une nouvelle array en rajoutant les conditions regex aux mots.

Pour exemple le message : "niQue panique nique, nique. nique pute cul culotté"
Donne : "***** panique *****, *****. ***** ***** ***** culotté"